### PR TITLE
More concise arrows

### DIFF
--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -1,11 +1,6 @@
 import React from 'react';
 
-const Message = (props) => {
-    const { text } = props;
-
-    return(
-        <div>{text}</div>
-    );
-};
+const Message = ({ text }) =>
+    <div>{text}</div>;
 
 export default Message;


### PR DESCRIPTION
By destructuring the arguments directly in the function signature, we can use concise return syntax arrows.